### PR TITLE
add prefix to tmp filename

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -44,7 +44,7 @@ import { fileURLToPath } from "node:url";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const exec = util.promisify(require("node:child_process").exec);
 
-const tmpFile = tmp.fileSync();
+const tmpFile = tmp.fileSync({ prefix: "nushell", keep: false });
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -363,7 +363,8 @@ async function runCompiler(
   let stdout = "";
   try {
     const output = await exec(
-      `/Users/jt/Source/nushell/target/debug/nu ${flags} ${tmpFile.name}`,
+      //   `/Users/jt/Source/nushell/target/debug/nu ${flags} ${tmpFile.name}`,
+      `/Users/fdncred/src/forks/nushell-ide/target/debug/nu ${flags} ${tmpFile.name}`,
       {
         timeout: 10000000,
       }


### PR DESCRIPTION
This PR adds a prefix on the tmp file name for easier identification of which files are created by nushell. The `keep: false` means the tmp files should be removed after usage but we may have to implement a cleanup routine. Not sure yet.